### PR TITLE
Simplifying the environment setup

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -11,12 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     # COULD_BE_BETTER: Consider turning this into a GitHub action - help the wider community
     # NDK install (unzipping) is really noisy - silence the log spam with grep, while keeping errors

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -12,12 +12,9 @@ jobs:
     timeout-minutes: 80
     steps:
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install NDK
       run: .github/scripts/install_ndk_macos.sh r22 22.0.7026061
@@ -84,12 +81,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       name: Checkout
-      with:
-          submodules: 'true' # anki is a submodule - and this is currently required by all gradle builds.
 
     # COULD_BE_BETTER: This may not be needed - tiny speed penalty
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Download APKs
       uses: actions/download-artifact@v2

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -6,12 +6,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install NDK
       run: .github/scripts/install_ndk.sh 22.0.7026061

--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -7,12 +7,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install NDK
       run: .github/scripts/install_ndk_macos.sh r22 22.0.7026061

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -42,9 +42,8 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: nightly # nightly is currently required for Robolectric Testing
+        toolchain: stable
         override: true
-        components: rustfmt, clippy
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -63,7 +63,11 @@ jobs:
       run: |
               export ANKIDROID_LINUX_CC=x86_64-unknown-linux-gnu-gcc
               export ANKIDROID_MACOS_CC=cc
-              ./gradlew clean rsdroid-testing:build -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain
+              export RUST_DEBUG=1
+              export RUST_BACKTRACE=1
+              export RUST_LOG=trace
+              export NO_CROSS=true
+              ./gradlew clean rsdroid-testing:build -Dorg.gradle.project.macCC=$ANKIDROID_MACOS_CC -DtestBuildType=debug -Dorg.gradle.daemon=false -Dorg.gradle.console=plain --warning-mode all
 
     - name: Check Compiled Libraries
       run: >

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -21,12 +21,9 @@ jobs:
 #      run: |
 #          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install NDK (r22 - 22.0.7026061)
       run: .github/scripts/install_ndk_macos.sh r22 22.0.7026061
@@ -98,8 +95,9 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # we need the .proto files, but not the i18n files in the recursive submodule (yet).
+
+    - name: Fetch submodules
+      run: git submodule update --init --recursive --remote --force
 
     - uses: actions/download-artifact@v2
       name: Download Artifact
@@ -158,12 +156,12 @@ jobs:
 
     - name: Install & Test Protobuf Compiler
       if: matrix.os != 'windows-latest'
-      shell: bash -l {0} 
+      shell: bash -l {0}
       run: |
               pip3 install protobuf
               pip3 install protobuf-compiler
               python3 .github/scripts/protoc_gen_deps.py
-              
+
     - name: Install & Test Protobuf Compiler (win)
       if: matrix.os == 'windows-latest'
       run: |
@@ -171,12 +169,12 @@ jobs:
               pip3 install protobuf
               pip3 install protobuf-compiler
               python3 .github/scripts/protoc_gen_deps.py
-              
+
     - name: Run Tests
       if: matrix.os != 'windows-latest'
-      shell: bash -l {0} 
+      shell: bash -l {0}
       run: ./gradlew rsdroid:test -x jar -x cargoBuildArm -x cargoBuildX86 -x cargoBuildArm64 -x cargoBuildX86_64
-      
+
     - name: Run Tests (win)
       if: matrix.os == 'windows-latest'
       run: ./gradlew rsdroid:test -x jar -x cargoBuildArm -x cargoBuildX86 -x cargoBuildArm64 -x cargoBuildX86_64

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -83,7 +83,7 @@ jobs:
       with:
         name: anki-proto
         if-no-files-found: error
-        path: anki/proto/
+        path: rslib-bridge/anki/proto/
 
   test:
     needs: build
@@ -109,12 +109,12 @@ jobs:
       name: Download fluent.proto
       with:
         name: anki-proto
-        path: anki/proto/
+        path: rslib-bridge/anki/proto/
 
     - name: Ensure fluent.proto exists
       if: matrix.os != 'windows-latest'
       run: |
-              if [ ! -f anki/proto/fluent.proto ]; then
+              if [ ! -f rslib-bridge/anki/proto/fluent.proto ]; then
                   echo "fluent.proto not generated"
                   exit 1
               fi

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
 
     # TODO: Ignore lines like we do in the Unix scripts, rather than all of them
     - name: Install NDK (silent)
@@ -46,9 +44,8 @@ jobs:
       run: |
             $Env:ANDROID_HOME
     
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6

--- a/.github/workflows/windows_pure_build.yml
+++ b/.github/workflows/windows_pure_build.yml
@@ -9,12 +9,9 @@ jobs:
     steps:
     
     - uses: actions/checkout@v2
-      with:
-          submodules: 'true' # anki is a submodule
     
-    # i18n did not seem to be handled
-    - name: Init i18n submodule
-      run: git submodule update --init --recursive
+    - name: Fetch submodules
+      run:  git submodule update --init --recursive --remote --force
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+javadoc/
+
 # built application files
 *.apk
 *.ap_

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "anki"]
-	path = anki
+	path = rslib-bridge/anki
 	url = https://github.com/david-allison-1/anki
 	branch = ankidroid-2-1-34

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,58 @@
+# Environment
+
+## Requirements
+
+- [ ] Clone the project
+    - [ ] Get all the submodules recursively 
+```bash
+$ git submodule update --init --recursive
+```
+- [ ] Install Docker (needed for cross compilation)
+    - [ ] Build all docker images
+```bash
+$ ./tools/build-docker-images.sh
+```
+- [ ] Android SDK
+- [ ] Android NDK
+    - You can find the exact needed version from `[rsdriod/build.gradle](./rsdriod/build.gradle)`
+```groovy
+android {
+    compileSdkVersion 30
+    buildToolsVersion "30.0.1"
+    ndkVersion "22.0.7026061" <------------- Here is the version
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+```
+- [ ] Rust
+    - You can easily install rust via [rustup](https://rustup.rs/)
+```
+- [ ] Add Android targets
+```bash
+$ rustup target add armv7-linux-androideabi   # arm
+$ rustup target add i686-linux-android        # x86
+$ rustup target add aarch64-linux-android     # arm64
+$ rustup target add x86_64-linux-android      # x86_64
+```
+- [ ] Install cross crate for cross compiling rust code
+```bash
+$ cargo install cross --git https://github.com/rust-embedded/cross/
+```
+- [ ] Install Python
+    - [ ] Install protobuf pakages
+```bash
+$ pip3 install protobuf
+$ pip3 install protobuf-compiler
+```
+
+## Note for macOS users
+You may face issues while trying to install protobuf packages. you can solve these issues by installing pythton 3.7.
+### Using pyenv
+https://github.com/pyenv/pyenv#installation
+### Using homebrew
+```bash
+$ brew install python@3.7
+$ brew link python@3.7 # if you do already a have a version installed unlink it first
+```

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -75,8 +75,8 @@ def toCommandLine(Platform targetPlatform) {
     // -Z unstable-options requires a 'nightly' toolchain
     // TODO: Explain how to select the version
 
-    def useCross = true
-    if (getCurrentPlatform() == targetPlatform) {
+    def useCross = System.getenv("NO_CROSS") != "true"
+    if (useCross && getCurrentPlatform() == targetPlatform) {
         useCross = false
     }
 

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -61,8 +61,16 @@ def getInputDir() {
     return canonicalPath
 }
 
+def getAssetsDir() {
+    return "${project.sourceSets.main.java.srcDirs[0]}/../../../assets";
+}
+
+def getTargetDir() {
+    return getInputDir() + "/target"
+}
+
 def toWindowsCommandLine(String command) {
-    def path = "${project.sourceSets.main.java.srcDirs[0]}/../../../assets"
+    def path = getAssetsDir()
     def canonicalAssetsPath = new File(path).getCanonicalPath()
     if (!new File(canonicalAssetsPath).exists()) {
         throw new FileNotFoundException("could not find output path: ${canonicalAssetsPath}")
@@ -80,7 +88,7 @@ def toCommandLine(Platform targetPlatform) {
         useCross = false
     }
 
-    def standardArg = "${useCross ? "cross" : "cargo"}  +nightly build --release -Z unstable-options --features no-android"
+    def standardArg = "${useCross ? "cross" : "cargo"} build --release --features no-android --verbose"
     def assetsPath = new File("${project.sourceSets.main.java.srcDirs[0]}/../../../assets").getCanonicalPath()
 
     String assetsSubPath = "/rsdroid-testing/assets"
@@ -91,14 +99,11 @@ def toCommandLine(Platform targetPlatform) {
             "/mnt/" + f.absolutePath[0].toLowerCase() + f.absolutePath.substring(1).replace(":\\", "\\").replace("\\", "/")
 
     println "Outputting to: ${path}"
-    def outDir = "--out-dir ${path}"
+    def outDir = ""
     System.out.println(assetsPath)
     def mainArg = standardArg + " " + outDir
     if (useCross) {
         mainArg = "DONT_RUSTFMT=1 " + mainArg //FIXME: try to mount $CARGO_HOME/bin and add it to path using cross
-
-        //instruct cross to mount the output directory
-        mainArg = "OUT_DIR=${path} " + mainArg
     }
     switch (targetPlatform) {
         case Platform.LINUX: return toWindowsCommandLine("CC=\$ANKIDROID_LINUX_CC ${mainArg} --target x86_64-unknown-linux-gnu")
@@ -147,10 +152,37 @@ task preBuildLinux(type: Exec) {
     commandLine(toCommandLine(Platform.LINUX))
 }
 
+task copyLinuxOutput(type: Copy) {
+    dependsOn preBuildLinux
+    File linuxDir = new File(targetDir, "x86_64-unknown-linux-gnu/release/")
+    from linuxDir
+    include "*.so"
+    into assetsDir
+}
+
+task copyMacOutput(type: Copy) {
+    dependsOn preBuildMac
+    File macosDir = new File(targetDir, "x86_64-apple-darwin/release/")
+    from macosDir
+    include "*.dylib"
+    into assetsDir
+}
+
+task copyWindowsOutput(type: Copy) {
+    dependsOn preBuildWindows
+    File windowsDir = new File(targetDir, "x86_64-pc-windows-gnu/release/")
+    from windowsDir
+    include "*.dll"
+    include "*.dll.a"
+    into assetsDir
+}
+
+
 // TODO: check for cargo
 // check for targets: x86_64-apple-darwin, x86_64-pc-windows-gnu, TODO: Linux
 
 processResources.dependsOn preBuildWindows
+processResources.dependsOn copyWindowsOutput
 // To fix: "toolchain 'nightly-x86_64-unknown-linux-gnu' is not installed"
 // execute in bash: rustup toolchain install nightly-x86_64-unknown-linux-gnu
 // "linker `x86_64-unknown-linux-gnu-gcc` not found"
@@ -159,12 +191,14 @@ processResources.dependsOn preBuildWindows
 // rustup target add x86_64-pc-windows-gnu --toolchain nightly
 // brew install mingw-w64 && x86_64-w64-mingw32-gcc -v
 processResources.dependsOn preBuildLinux
+processResources.dependsOn copyLinuxOutput
 
 if (org.gradle.internal.os.OperatingSystem.current().isMacOsX()) {
     // due to restrictions on downloading the MacOS SDK, we can only build for MacOS on MacOS
     // > Install a reasonable number of copies of the Apple Software on Apple-branded computers
     // https://www.apple.com/legal/sla/docs/xcode.pdf
     processResources.dependsOn preBuildMac
+    processResources.dependsOn copyMacOutput
 }
 
 signing {

--- a/rsdroid-testing/build.gradle
+++ b/rsdroid-testing/build.gradle
@@ -43,6 +43,15 @@ enum Platform {
     LINUX, MACOS, WINDOWS
 }
 
+def Platform getCurrentPlatform() {
+    def currentOS = org.gradle.internal.os.OperatingSystem.current()
+    if (currentOS.isWindows()) return Platform.WINDOWS
+    if (currentOS.isMacOsX()) return Platform.MACOS
+    if (currentOS.isLinux()) return Platform.LINUX
+
+    throw "Unsuported OS"
+}
+
 def getInputDir() {
     def path = "${project.sourceSets.main.java.srcDirs[0]}/../../../../rslib-bridge"
     def canonicalPath = new File(path).getCanonicalPath()
@@ -65,7 +74,13 @@ def toCommandLine(Platform targetPlatform) {
     // the --out-dir flag requires -Z unstable-options
     // -Z unstable-options requires a 'nightly' toolchain
     // TODO: Explain how to select the version
-    def standardArg = "cargo  +nightly build --release -Z unstable-options --features no-android"
+
+    def useCross = true
+    if (getCurrentPlatform() == targetPlatform) {
+        useCross = false
+    }
+
+    def standardArg = "${useCross ? "cross" : "cargo"}  +nightly build --release -Z unstable-options --features no-android"
     def assetsPath = new File("${project.sourceSets.main.java.srcDirs[0]}/../../../assets").getCanonicalPath()
 
     String assetsSubPath = "/rsdroid-testing/assets"
@@ -79,6 +94,12 @@ def toCommandLine(Platform targetPlatform) {
     def outDir = "--out-dir ${path}"
     System.out.println(assetsPath)
     def mainArg = standardArg + " " + outDir
+    if (useCross) {
+        mainArg = "DONT_RUSTFMT=1 " + mainArg //FIXME: try to mount $CARGO_HOME/bin and add it to path using cross
+
+        //instruct cross to mount the output directory
+        mainArg = "OUT_DIR=${path} " + mainArg
+    }
     switch (targetPlatform) {
         case Platform.LINUX: return toWindowsCommandLine("CC=\$ANKIDROID_LINUX_CC ${mainArg} --target x86_64-unknown-linux-gnu")
         case Platform.MACOS:

--- a/rsdroid/proto.gradle
+++ b/rsdroid/proto.gradle
@@ -1,6 +1,6 @@
 import org.gradle.internal.os.OperatingSystem
 
-def protobufFolder = new File(rootDir, "anki/proto").getAbsolutePath()
+def protobufFolder = new File(rootDir, "rslib-bridge/anki/proto").getAbsolutePath()
 def droidProtobufFolder = new File(rootDir, "rslib-bridge/proto").getAbsolutePath()
 
 android {

--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -11,7 +11,7 @@ crate_type = ["dylib"]
 
 [dependencies]
 jni = { version = "0.17.0", default-features = false }
-anki = { path = "../anki/rslib" }
+anki = { path = "anki/rslib" }
 prost = "0.6.1"
 serde = "1.0.114"
 serde_json = "1.0.56"

--- a/rslib-bridge/Cross.toml
+++ b/rslib-bridge/Cross.toml
@@ -1,0 +1,18 @@
+[build.env]
+passthrough = [
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    "RUST_DEBUG",
+    "DONT_RUSTFMT"
+]
+
+volumes = [
+    "OUT_DIR",
+]
+
+
+[target.x86_64-unknown-linux-gnu]
+image = "ankidroid/rslib-bridge:linux"
+
+[target.x86_64-pc-windows-gnu]
+image = "ankidroid/rslib-bridge:windows"

--- a/rslib-bridge/Dockerfiles/Dockerfile.linux
+++ b/rslib-bridge/Dockerfiles/Dockerfile.linux
@@ -1,4 +1,5 @@
-FROM rustembedded/cross:x86_64-unknown-linux-gnu
+# rustembedded/cross:x86_64-unknown-linux-gnu
+FROM rustembedded/cross@sha256:f4bdeb42de213e8bb5baf6d2064943331d957fa3f24837ce88c1dd4945bf59aa
 
 # fix for error: linker `x86_64-unknown-linux-gnu-gcc` not found
 RUN ln -s /usr/bin/cc /usr/local/bin/x86_64-unknown-linux-gnu-gcc

--- a/rslib-bridge/Dockerfiles/Dockerfile.linux
+++ b/rslib-bridge/Dockerfiles/Dockerfile.linux
@@ -1,0 +1,4 @@
+FROM rustembedded/cross:x86_64-unknown-linux-gnu
+
+# fix for error: linker `x86_64-unknown-linux-gnu-gcc` not found
+RUN ln -s /usr/bin/cc /usr/local/bin/x86_64-unknown-linux-gnu-gcc

--- a/rslib-bridge/Dockerfiles/Dockerfile.windows
+++ b/rslib-bridge/Dockerfiles/Dockerfile.windows
@@ -1,0 +1,4 @@
+FROM rustembedded/cross:x86_64-pc-windows-gnu
+
+# fix for error: linker `x86_64-unknown-linux-gnu-gcc` not found
+RUN ln -s /usr/bin/cc /usr/local/bin/x86_64-unknown-linux-gnu-gcc

--- a/rslib-bridge/Dockerfiles/Dockerfile.windows
+++ b/rslib-bridge/Dockerfiles/Dockerfile.windows
@@ -1,4 +1,5 @@
-FROM rustembedded/cross:x86_64-pc-windows-gnu
+# rustembedded/cross:x86_64-pc-windows-gnu
+FROM rustembedded/cross@sha256:5005553ddf4e82d4703ee7f458a24802a014f03884f87c6277e9c718765d3517
 
 # fix for error: linker `x86_64-unknown-linux-gnu-gcc` not found
 RUN ln -s /usr/bin/cc /usr/local/bin/x86_64-unknown-linux-gnu-gcc

--- a/rslib-bridge/build.rs
+++ b/rslib-bridge/build.rs
@@ -92,14 +92,18 @@ fn main() -> std::io::Result<()> {
         .service_generator(service_generator())
         .compile_protos(&["proto/AdBackend.proto"], &["proto"])
         .unwrap();
-		
-    // rustfmt the protobuf code
-    let rustfmt = Command::new("rustfmt")
-        .arg(Path::new("src/backend_proto.rs"))
-        .status()
-        .unwrap();
-		
-    assert!(rustfmt.success(), "rustfmt backend_proto.rs failed");
+
+    if let Err(e) = std::env::var("DONT_RUSTFMT") {
+        assert_eq!(e, std::env::VarError::NotPresent);
+        println!("Using rustfmt to format src/backend_proto.rs");
+        // rustfmt the protobuf code
+        let rustfmt = Command::new("rustfmt")
+            .arg(Path::new("src/backend_proto.rs"))
+            .status()
+            .unwrap();
+
+        assert!(rustfmt.success(), "rustfmt backend_proto.rs failed");
+    }
 
     Ok(())
 }

--- a/rslib-bridge/src/sqlite.rs
+++ b/rslib-bridge/src/sqlite.rs
@@ -140,7 +140,7 @@ pub(crate) fn open_or_create_no_update(path: &Path, _i18n: &I18n, _server: bool,
 
 
     db.execute("begin exclusive", NO_PARAMS)?;
-    db.execute_batch(include_str!("../../anki/rslib/src/storage/schema11.sql"))?;
+    db.execute_batch(include_str!("../anki/rslib/src/storage/schema11.sql"))?;
     // start at schema 11, then upgrade below
     let crt = v1_creation_date();
     db.execute(

--- a/tools/build-docker-images.sh
+++ b/tools/build-docker-images.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+echo -e "\e[1;33m>>> Building Linux Image\e[0m (x86_64-unknown-linux-gnu) "
+docker build -t ankidroid/rslib-bridge:linux . -f ./rslib-bridge/Dockerfiles/Dockerfile.linux
+
+
+
+echo -e "\e[1;33m>>> Building Windows Image\e[0m (x86_64-pc-windows-gnu)"
+docker build -t ankidroid/rslib-bridge:windows . -f ./rslib-bridge/Dockerfiles/Dockerfile.windows

--- a/tools/doctor.sh
+++ b/tools/doctor.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -e # Error out if there were any problems
+
+ANDROID_NDK_VERSION="22.0.7026061"
+
+red=31
+green=32
+yellow=33
+blue=34
+purple=35
+cyan=36
+lgray=37
+gray=90
+normal=0
+bold=1
+
+cecho() {
+  echo -e "\033[$bold;$1m$2\033[0m"
+}
+
+error_echo() {
+  cecho $red "✗ $1"
+  exit 1
+}
+
+ok_echo() {
+  cecho $green "✓ $1"
+}
+
+cecho $lgray"##################################"
+cecho $lgray "# AnkiDroidBackend Docker Script #"
+cecho $lgray "##################################\n"
+
+cecho $lgray "Getting all submodules recursively"
+git submodule update --init --recursive
+
+
+if [[ $(which docker) && $(docker --version) ]]; then
+  ok_echo "Docker is installed"
+else
+  error_echo "Docker is not installed. please install it first"
+fi
+
+
+cecho $lgray "Building docker images"
+./tools/build-docker-images.sh
+
+
+if [[ -n "$ANDROID_SDK_ROOT" ]]; then
+  ok_echo "ANDROID_SDK_ROOT is set"
+else
+  error_echo "ANDROID_SDK_ROOT should point to your SDK installation"
+fi
+
+
+if [[ -d "$ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION" ]]; then
+  ok_echo "NDK $ANDROID_NDK_VERSION directory found"
+else
+  echo -e "Expected to find: $ANDROID_SDK_ROOT/ndk/$ANDROID_NDK_VERSION"
+  error_echo "NDK $ANDROID_NDK_VERSION directory found"
+fi
+
+
+cecho $lgray "Installing rust nightly"
+rustup install nightly
+
+
+cecho $lgray "Adding rust android targets"
+rustup target add armv7-linux-androideabi   # arm
+rustup target add i686-linux-android        # x86
+rustup target add aarch64-linux-android     # arm64
+rustup target add x86_64-linux-android      # x86_64
+
+cecho $lgray "Installing cross"
+cargo install cross --git https://github.com/rust-embedded/cross/
+
+
+cecho $lgray "Installing protobuf python libraries"
+
+if [[ $(pip3 install protobuf) && $(pip3 install protobuf-compiler) ]]; then
+  ok_echo "Protobuf python libraries are installed"
+else
+    echo -e "Try installing with python 3.7"
+    error_echo "Failed installing Protobuf python libraries"
+fi


### PR DESCRIPTION
Use cross to simplify the process of cross compiling 

Related to #9

+ Added a flag to disable formatting using `rustfmt`
+ Changed the anki submodule to use my fork where I added the same flag
+ Moved anki to be under `rslib-bridge` because of a limitation using cross with local dependencies.
+ Modified gradle to utilize cross 