### PR TITLE
Fix CI: Linux/macOS

### DIFF
--- a/.github/scripts/install_ndk_macos.sh
+++ b/.github/scripts/install_ndk_macos.sh
@@ -1,8 +1,14 @@
 : ${2?"Usage: $0 NDK Short Version (r22), NDK Long Version (22.0.7026061) "}
 # We don't use sdkmanager due to https://stackoverflow.com/questions/46402772/failed-to-install-android-sdk-java-lang-noclassdeffounderror-javax-xml-bind-a
-echo 'Downloading NDK'
-wget --no-verbose -O android-ndk.zip "https://dl.google.com/android/repository/android-ndk-$1-darwin-x86_64.zip"
-echo 'Unzipping NDK'
-unzip -q -d $2 android-ndk.zip
-mkdir $ANDROID_SDK_ROOT/ndk/$2/
-mv $2/*/* $ANDROID_SDK_ROOT/ndk/$2
+
+if [ ! -d "$ANDROID_SDK_ROOT/ndk/$2/" ]
+then
+  echo 'Downloading NDK'
+  wget --no-verbose -O android-ndk.zip "https://dl.google.com/android/repository/android-ndk-$1-darwin-x86_64.zip"
+  echo 'Unzipping NDK'
+  unzip -q -d $2 android-ndk.zip
+  mkdir $ANDROID_SDK_ROOT/ndk/$2/
+  mv $2/*/* $ANDROID_SDK_ROOT/ndk/$2
+else
+  echo 'Skipping NDK download - already installed'
+fi

--- a/.github/scripts/macos_install_protobuf_compiler.sh
+++ b/.github/scripts/macos_install_protobuf_compiler.sh
@@ -21,6 +21,7 @@ pyenv install 3.7.9
 pyenv shell 3.7.9
 pyenv global 3.7.9
 python3 -v
+sudo apt-get install python3-dev
 pip3 install protobuf
 pip3 install protobuf-compiler
 .github/scripts/protoc_gen_deps.py

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -50,9 +50,21 @@ jobs:
    #   run: sudo apt update && sudo apt install android-sdk
 
     - name: Install google protobuf compiler
-      run: >
-              sudo apt-get install python3-setuptools &&
-              pip3 install protobuf-compiler &&
+      run: |
+              python --version
+              git clone https://github.com/pyenv/pyenv.git ~/.pyenv
+              echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
+              echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
+              echo 'export GITHUB_PATH="$PYENV_ROOT/bin:$GITHUB_PATH"' >> ~/.bash_profile
+              echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
+              source ~/.bash_profile
+              echo "Installing Python 3.7.9"
+              pyenv install 3.7.9
+              pyenv shell 3.7.9
+              pyenv global 3.7.9
+              python --version
+              pip3 install setuptools
+              pip3 install protobuf-compiler
               .github/scripts/protoc_gen_deps.py
 
     - name: Build


### PR DESCRIPTION
Fixes #37 

* MacOS - NDK Already installed
    * `mv: rename 22.0.7026061/android-ndk-r22/build to /Users/runner/Library/Android/sdk/ndk/22.0.7026061/build: Directory not empty`
* MacOS - Python/Protobuf
    * `distutils.errors.CompileError: command 'x86_64-linux-gnu-gcc' failed with exit status 1`
* Linux - Python/Protobuf    
    * `distutils.errors.CompileError: command 'x86_64-linux-gnu-gcc' failed with exit status 1`