### PR TITLE
Expose anki commit hash in rsdriod.

### DIFF
--- a/rsdroid/build.gradle
+++ b/rsdroid/build.gradle
@@ -3,6 +3,17 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'signing'
 apply plugin: 'com.vanniktech.maven.publish'
 
+def getAnkiCommitHash = { ->
+    def hashStdOut = new ByteArrayOutputStream()
+    exec {
+        commandLine "git", "-C", new File("${project.rootDir}", "rslib-bridge/anki"), "rev-parse", "HEAD"
+        standardOutput = hashStdOut
+    }
+    def commit = hashStdOut.toString().trim()
+    println("Anki commit: ${commit}")
+    return commit
+}
+
 android {
     compileSdkVersion 30
     buildToolsVersion "30.0.1"
@@ -20,6 +31,8 @@ android {
         versionName VERSION_NAME
 
         consumerProguardFiles "consumer-rules.pro"
+
+        buildConfigField("String", "ANKI_COMMIT_HASH", "\"${getAnkiCommitHash()}\"")
     }
 
     buildTypes {

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendUtils.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendUtils.java
@@ -16,6 +16,8 @@
 
 package net.ankiweb.rsdroid;
 
+import androidx.annotation.NonNull;
+
 import BackendProto.Backend;
 
 public class BackendUtils {
@@ -25,5 +27,10 @@ public class BackendUtils {
      */
     public static void openAnkiDroidCollection(BackendV1 backendV1, String path) {
         backendV1.openAnkiDroidCollection(Backend.OpenCollectionIn.newBuilder().setCollectionPath(path).build());
+    }
+
+    @NonNull
+    public static String getAnkiCommitHash() {
+        return BuildConfig.ANKI_COMMIT_HASH;
     }
 }


### PR DESCRIPTION
Fixes #25,

This points to `rslib-bridge/anki` not `anki`.

`rslib-bridge/anki` should be here as soon as #39 is merged.