### PR TITLE
CI: Reduce timeouts

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 80
     runs-on: ubuntu-latest
     # env:
       # required for "act": https://github.com/nektos/act/issues/265

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 80
     steps:
     - uses: actions/checkout@v2
       with:
@@ -74,6 +75,7 @@ jobs:
   test:
     needs: build
     runs-on: macos-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: macos-latest
+    timeout-minutes: 80
     steps:
 #    - name: Configure Mac OS environment variables
         # gnu tar for cache issue: https://github.com/actions/cache/issues/403
@@ -90,6 +91,7 @@ jobs:
   test:
     needs: build
     runs-on: ${{matrix.os}}
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 80
     runs-on: windows-latest
     steps:
 


### PR DESCRIPTION
Fixes #44

We had a stuck action, make the timeouts more reasonable (instead of 6 hours)

Historically, none of the jobs took more than an hour total, so we have leeway