### PR TITLE
rsdroid-testing: Diagnose Crash

### DIFF
--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
@@ -17,6 +17,7 @@
 package net.ankiweb.rsdroid.testing;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -99,6 +100,10 @@ public class RustBackendLoader {
         try {
             Runtime.getRuntime().load(path);
         } catch (UnsatisfiedLinkError e) {
+            if (!new File(path).exists()) {
+                FileNotFoundException exception = new FileNotFoundException("Extracted file was not found. Maybe the temp folder was deleted. Please try again: '" + path + "'");
+                throw new RuntimeException(exception);
+            }
             if (e.getMessage() == null || !e.getMessage().contains("already loaded in another classloader")) {
                 throw e;
             }

--- a/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
+++ b/rsdroid-testing/src/main/java/net/ankiweb/rsdroid/testing/RustBackendLoader.java
@@ -34,6 +34,8 @@ public class RustBackendLoader {
     private static boolean alreadyLoaded;
     private static final HashMap<String, String> FILENAME_TO_PATH_CACHE = new HashMap<>();
 
+    public static boolean PRINT_DEBUG = false;
+
     /**
      * Allows unit testing rsdroid under Robolectric <br/>
      * Loads (via {@link Runtime#load(String)}) a librsdroid.so alternative compiled for the current operating system.<br/><br/>
@@ -46,6 +48,10 @@ public class RustBackendLoader {
      */
     public static void init() {
         if (!alreadyLoaded) {
+
+            // This should help diagnose some issues,
+            print("loading rsdroid-testing for: " + System.getProperty("os.name"));
+
             if (OS.isFamilyWindows()) {
                 load("rsdroid", ".dll");
             } else if (OS.isFamilyMac()) {
@@ -58,6 +64,12 @@ public class RustBackendLoader {
             }
 
             alreadyLoaded = true;
+        }
+    }
+
+    private static void print(String message) {
+        if (PRINT_DEBUG) {
+            System.out.println(message);
         }
     }
 


### PR DESCRIPTION
A user had a crash where `rsdroid-testing`'s DLL couldn't be loaded

This adds some diagnostics which should help diagnose the issue

Fixes #46