### PR TITLE
Add BackendException subclasses to match libanki's error classes

### DIFF
--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendForTesting.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendForTesting.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid;
+
+import androidx.annotation.VisibleForTesting;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import BackendProto.Backend;
+
+public class BackendForTesting extends BackendV1Impl {
+
+    BackendForTesting() {
+        super();
+    }
+
+    public static BackendForTesting create() {
+        try {
+            NativeMethods.ensureSetup();
+        } catch (RustBackendFailedException e) {
+            throw new RuntimeException(e);
+        }
+        return new BackendForTesting();
+    }
+
+
+    // Debug methods
+
+    /**
+     * Throws a given error, generated from the Rust
+     * @param error The error to throw
+     */
+    @VisibleForTesting
+    public void debugProduceError(ErrorType error) {
+        byte[] result = null;
+        try {
+            Pointer backendPointer = ensureBackend();
+            result = NativeMethods.debugProduceError(backendPointer.toJni(), error.toString());
+
+            // This should fail validate
+            Backend.Empty message = Backend.Empty.parseFrom(result);
+            validateMessage(result, message);
+
+            throw new IllegalStateException("An exception should have been thrown");
+
+        } catch (InvalidProtocolBufferException ex) {
+            validateResult(result);
+            throw BackendException.fromException(ex);
+        }
+    }
+
+
+    public enum ErrorType {
+        InvalidInput,
+        TemplateError,
+        TemplateSaveError,
+        IOError,
+        DbErrorFileTooNew,
+        DbErrorFileTooOld,
+        DbErrorMissingEntity,
+        DbErrorCorrupt,
+        DbErrorLocked,
+        DbErrorOther,
+        NetworkErrorOffline,
+        NetworkErrorTimeout,
+        NetworkErrorProxyAuth,
+        NetworkErrorOther,
+        SyncErrorConflict,
+        SyncErrorServerError,
+        SyncErrorClientTooOld,
+        SyncErrorAuthFailed,
+        SyncErrorServerMessage,
+        SyncErrorClockIncorrect,
+        SyncErrorOther,
+        SyncErrorResyncRequired,
+        SyncErrorDatabaseCheckRequired,
+        JSONError,
+        ProtoError,
+        Interrupted,
+        CollectionNotOpen,
+        CollectionAlreadyOpen,
+        NotFound,
+        Existing,
+        DeckIsFiltered,
+        SearchError,
+        FatalError;
+
+        public String toString() {
+            switch (this) {
+                case InvalidInput:
+                    return "InvalidInput";
+                case TemplateError:
+                    return "TemplateError";
+                case TemplateSaveError:
+                    return "TemplateSaveError";
+                case IOError:
+                    return "IOError";
+                case DbErrorFileTooNew:
+                    return "DbErrorFileTooNew";
+                case DbErrorFileTooOld:
+                    return "DbErrorFileTooOld";
+                case DbErrorMissingEntity:
+                    return "DbErrorMissingEntity";
+                case DbErrorCorrupt:
+                    return "DbErrorCorrupt";
+                case DbErrorLocked:
+                    return "DbErrorLocked";
+                case DbErrorOther:
+                    return "DbErrorOther";
+                case NetworkErrorOffline:
+                    return "NetworkErrorOffline";
+                case NetworkErrorTimeout:
+                    return "NetworkErrorTimeout";
+                case NetworkErrorProxyAuth:
+                    return "NetworkErrorProxyAuth";
+                case NetworkErrorOther:
+                    return "NetworkErrorOther";
+                case SyncErrorConflict:
+                    return "SyncErrorConflict";
+                case SyncErrorServerError:
+                    return "SyncErrorServerError";
+                case SyncErrorClientTooOld:
+                    return "SyncErrorClientTooOld";
+                case SyncErrorAuthFailed:
+                    return "SyncErrorAuthFailed";
+                case SyncErrorServerMessage:
+                    return "SyncErrorServerMessage";
+                case SyncErrorClockIncorrect:
+                    return "SyncErrorClockIncorrect";
+                case SyncErrorOther:
+                    return "SyncErrorOther";
+                case SyncErrorResyncRequired:
+                    return "SyncErrorResyncRequired";
+                case SyncErrorDatabaseCheckRequired:
+                    return "SyncErrorDatabaseCheckRequired";
+                case JSONError:
+                    return "JSONError";
+                case ProtoError:
+                    return "ProtoError";
+                case Interrupted:
+                    return "Interrupted";
+                case CollectionNotOpen:
+                    return "CollectionNotOpen";
+                case CollectionAlreadyOpen:
+                    return "CollectionAlreadyOpen";
+                case NotFound:
+                    return "NotFound";
+                case Existing:
+                    return "Existing";
+                case DeckIsFiltered:
+                    return "DeckIsFiltered";
+                case SearchError:
+                    return "SearchError";
+                case FatalError:
+                    return "FatalError";
+                default: throw new IllegalStateException("Unknown: " + this);
+            }
+        }
+    }
+}

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ExceptionTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid;
+
+import android.database.sqlite.SQLiteDatabaseCorruptException;
+
+import net.ankiweb.rsdroid.database.NotImplementedException;
+import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException;
+import net.ankiweb.rsdroid.exceptions.BackendExistingException;
+import net.ankiweb.rsdroid.exceptions.BackendInterruptedException;
+import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException;
+import net.ankiweb.rsdroid.exceptions.BackendIoException;
+import net.ankiweb.rsdroid.exceptions.BackendJsonException;
+import net.ankiweb.rsdroid.exceptions.BackendNetworkException;
+import net.ankiweb.rsdroid.exceptions.BackendProtoException;
+import net.ankiweb.rsdroid.exceptions.BackendSyncException;
+import net.ankiweb.rsdroid.exceptions.BackendTemplateException;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.fail;
+
+@RunWith(Parameterized.class)
+public class ExceptionTest {
+
+    private BackendForTesting backend;
+
+    @Parameterized.Parameter()
+    public BackendForTesting.ErrorType errorType;
+
+    @Parameterized.Parameter(value = 1)
+    public Class<? extends Exception> clazz;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static java.util.Collection<Object[]> initParameters() {
+        // This does one run with schedVersion injected as 1, and one run as 2
+
+        // If an exception does not provide enough information to handle it
+        Class<NotImplementedException> NOT_POSSIBLE = NotImplementedException.class;
+
+        return Arrays.asList(new Object[][] {
+            // converted to invalid input protobuf - not available
+            { BackendForTesting.ErrorType.CollectionAlreadyOpen, BackendInvalidInputException.BackendCollectionAlreadyOpenException.class },
+            { BackendForTesting.ErrorType.CollectionNotOpen, BackendInvalidInputException.BackendCollectionNotOpenException.class },
+            { BackendForTesting.ErrorType.SearchError, NOT_POSSIBLE },
+
+            { BackendForTesting.ErrorType.SyncErrorAuthFailed, BackendSyncException.BackendSyncAuthFailedException.class },
+            { BackendForTesting.ErrorType.SyncErrorClientTooOld, BackendSyncException.BackendSyncClientTooOldException.class },
+            { BackendForTesting.ErrorType.SyncErrorClockIncorrect, BackendSyncException.BackendSyncClockIncorrectException.class },
+            { BackendForTesting.ErrorType.SyncErrorConflict, BackendSyncException.BackendSyncConflictException.class },
+            { BackendForTesting.ErrorType.SyncErrorDatabaseCheckRequired, BackendSyncException.BackendSyncDatabaseCheckRequiredException.class },
+            { BackendForTesting.ErrorType.SyncErrorResyncRequired, BackendSyncException.BackendSyncResyncRequiredException.class },
+            { BackendForTesting.ErrorType.SyncErrorServerMessage, BackendSyncException.BackendSyncServerMessageException.class },
+            { BackendForTesting.ErrorType.SyncErrorServerError, BackendSyncException.BackendSyncServerErrorException.class },
+
+            { BackendForTesting.ErrorType.SyncErrorOther, BackendSyncException.class },
+
+            { BackendForTesting.ErrorType.DbErrorCorrupt, NOT_POSSIBLE },
+
+            { BackendForTesting.ErrorType.DbErrorFileTooNew, BackendException.BackendDbException.BackendDbFileTooNewException.class},
+            { BackendForTesting.ErrorType.DbErrorFileTooOld, BackendException.BackendDbException.BackendDbFileTooOldException.class},
+            { BackendForTesting.ErrorType.DbErrorLocked, BackendException.BackendDbException.BackendDbLockedException.class},
+            { BackendForTesting.ErrorType.DbErrorMissingEntity, BackendException.BackendDbException.BackendDbMissingEntityException.class},
+
+            { BackendForTesting.ErrorType.DbErrorOther, BackendException.BackendDbException.class},
+
+
+            { BackendForTesting.ErrorType.NetworkErrorOffline, BackendNetworkException.BackendNetworkOfflineException.class},
+            { BackendForTesting.ErrorType.NetworkErrorProxyAuth, BackendNetworkException.BackendNetworkProxyAuthException.class},
+            { BackendForTesting.ErrorType.NetworkErrorTimeout, BackendNetworkException.BackendNetworkTimeoutException.class},
+
+            { BackendForTesting.ErrorType.NetworkErrorOther, BackendNetworkException.class},
+
+            { BackendForTesting.ErrorType.DeckIsFiltered, BackendDeckIsFilteredException.class },
+            { BackendForTesting.ErrorType.Existing, BackendExistingException.class },
+            { BackendForTesting.ErrorType.FatalError, BackendFatalError.class },
+            { BackendForTesting.ErrorType.Interrupted, BackendInterruptedException.class},
+            { BackendForTesting.ErrorType.InvalidInput, BackendInvalidInputException.class},
+            { BackendForTesting.ErrorType.IOError, BackendIoException.class},
+            { BackendForTesting.ErrorType.JSONError, BackendJsonException.class },
+            { BackendForTesting.ErrorType.ProtoError, BackendProtoException.class },
+            { BackendForTesting.ErrorType.TemplateError, BackendTemplateException.class},
+            { BackendForTesting.ErrorType.TemplateSaveError, BackendTemplateException.BackendTemplateSaveException.class},
+        });
+    }
+
+
+    @Before
+    public void errorProducesNamedException() {
+        backend = BackendForTesting.create();
+    }
+
+    @Test
+    public void testError() {
+        if (NotImplementedException.class.equals(clazz)) {
+            //noinspection ConstantConditions
+            Assume.assumeTrue("This case cannot be handled yet", false);
+        }
+
+        assertThrows(errorType, clazz);
+    }
+
+    private void assertThrows(BackendForTesting.ErrorType e, Class<? extends Exception> clazz) {
+        try {
+            backend.debugProduceError(e);
+            fail();
+        } catch (Throwable ex) { // we catch BackendFatalError here
+            if (!ex.getClass().equals(clazz)) {
+                Assert.fail("ex was not an instance of " + clazz.getSimpleName() + ". Instead: " + ex.getClass() + ". message: " + ex.getMessage());
+            }
+        }
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/NativeMethods.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/NativeMethods.java
@@ -5,6 +5,7 @@ import android.os.Build;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import timber.log.Timber;
 
@@ -96,4 +97,10 @@ public class NativeMethods {
     static native long closeBackend(long backendPointer);
 
     static native byte[] executeAnkiDroidCommand(long backendPointer, int command, byte[] args);
+
+    /**
+     * Produces all possible Rust-based errors.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    static native byte[] debugProduceError(long backendPointer, String command);
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendDeckIsFilteredException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendDeckIsFilteredException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendDeckIsFilteredException extends BackendException {
+    public BackendDeckIsFilteredException(Backend.BackendError error) {
+        super(error);
+    }
+}
+

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendExistingException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendExistingException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+/**
+ * TODO: Document this
+ */
+public class BackendExistingException extends BackendException {
+    public BackendExistingException(Backend.BackendError error) {
+        super(error);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendInterruptedException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendInterruptedException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendInterruptedException extends BackendException {
+    public BackendInterruptedException(Backend.BackendError error) {
+        super(error);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendInvalidInputException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendInvalidInputException.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+/**
+ * A lot of exceptions get converted to Invalid Input when returned:
+ *
+ * CollectionNotOpen
+ * CollectionAlreadyOpen
+ * SearchError
+ */
+public class BackendInvalidInputException extends BackendException {
+    public BackendInvalidInputException(Backend.BackendError error) {
+        super(error);
+    }
+
+    public static BackendInvalidInputException fromInvalidInputError(Backend.BackendError error) {
+        switch (error.getLocalized()) {
+            case "CollectionAlreadyOpen": return new BackendCollectionAlreadyOpenException(error);
+            case "CollectionNotOpen": return new BackendCollectionNotOpenException(error);
+            // TODO: We can't handle this case as there's no available properties.
+            // case "SearchError": return new BackendSearchException(error);
+        }
+        return new BackendInvalidInputException(error);
+    }
+
+    public static class BackendCollectionAlreadyOpenException extends BackendInvalidInputException {
+        public BackendCollectionAlreadyOpenException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendCollectionNotOpenException extends BackendInvalidInputException {
+        public BackendCollectionNotOpenException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSearchException extends BackendInvalidInputException {
+        public BackendSearchException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendIoException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendIoException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendIoException extends BackendException {
+    public BackendIoException(Backend.BackendError error) {
+        super(error);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendJsonException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendJsonException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendJsonException extends BackendException {
+    public BackendJsonException(Backend.BackendError error) {
+        super(error);
+    }
+
+    public BackendJsonException(String message) {
+        super(message);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendNetworkException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendNetworkException.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendNetworkException extends BackendException {
+    public BackendNetworkException(Backend.BackendError error) {
+        super(error);
+    }
+
+    public static BackendNetworkException fromNetworkError(Backend.BackendError error) {
+
+        if (!error.hasNetworkError()) {
+            return new BackendNetworkException(error);
+        }
+
+        Backend.NetworkError networkError = error.getNetworkError();
+
+        switch (networkError.getKind()) {
+            case OFFLINE: return new BackendNetworkOfflineException(error);
+            case TIMEOUT: return new BackendNetworkTimeoutException(error);
+            case PROXY_AUTH: return new BackendNetworkProxyAuthException(error);
+            case UNRECOGNIZED:
+            case OTHER:
+        }
+
+        return new BackendNetworkException(error);
+    }
+
+    public static class BackendNetworkOfflineException extends BackendNetworkException {
+        public BackendNetworkOfflineException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendNetworkTimeoutException extends BackendNetworkException {
+        public BackendNetworkTimeoutException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendNetworkProxyAuthException extends BackendNetworkException {
+        public BackendNetworkProxyAuthException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendNotFoundException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendNotFoundException extends BackendException {
+    public BackendNotFoundException(Backend.BackendError error) {
+        super(error);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendProtoException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendProtoException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendProtoException extends BackendException {
+    public BackendProtoException(Backend.BackendError error) {
+        super(error);
+    }
+}
+

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendSyncException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendSyncException.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendSyncException extends BackendException {
+
+    public BackendSyncException(Backend.BackendError error) {
+        super(error);
+    }
+
+
+    public static BackendSyncException fromSyncError(Backend.BackendError error) {
+
+        switch (error.getSyncError().getKind()) {
+            case CONFLICT:
+                throw new BackendSyncConflictException(error);
+            case AUTH_FAILED:
+                throw new BackendSyncAuthFailedException(error);
+            case SERVER_ERROR:
+                throw new BackendSyncServerErrorException(error);
+            case UNRECOGNIZED:
+                throw new BackendSyncUnrecognizedException(error);
+            case CLIENT_TOO_OLD:
+                throw new BackendSyncClientTooOldException(error);
+            case SERVER_MESSAGE:
+                throw new BackendSyncServerMessageException(error);
+            case CLOCK_INCORRECT:
+                throw new BackendSyncClockIncorrectException(error);
+            case RESYNC_REQUIRED:
+                throw new BackendSyncResyncRequiredException(error);
+            case MEDIA_CHECK_REQUIRED:
+                throw new BackendSyncMediaCheckRequiredException(error);
+            case DATABASE_CHECK_REQUIRED:
+                throw new BackendSyncDatabaseCheckRequiredException(error);
+            case OTHER:
+            default:
+                throw new BackendSyncException(error);
+        }
+    }
+
+    public static class BackendSyncConflictException extends BackendSyncException {
+        public BackendSyncConflictException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncAuthFailedException extends BackendSyncException {
+        public BackendSyncAuthFailedException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncServerErrorException extends BackendSyncException {
+        public BackendSyncServerErrorException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncUnrecognizedException extends BackendSyncException {
+        public BackendSyncUnrecognizedException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncClientTooOldException extends BackendSyncException {
+        public BackendSyncClientTooOldException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncClockIncorrectException extends BackendSyncException {
+        public BackendSyncClockIncorrectException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncServerMessageException extends BackendSyncException {
+        public BackendSyncServerMessageException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncResyncRequiredException extends BackendSyncException {
+        public BackendSyncResyncRequiredException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncMediaCheckRequiredException extends BackendSyncException {
+        public BackendSyncMediaCheckRequiredException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+
+    public static class BackendSyncDatabaseCheckRequiredException extends BackendSyncException {
+        public BackendSyncDatabaseCheckRequiredException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendTemplateException.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/exceptions/BackendTemplateException.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.exceptions;
+
+import net.ankiweb.rsdroid.BackendException;
+
+import BackendProto.Backend;
+
+public class BackendTemplateException extends BackendException {
+    public BackendTemplateException(Backend.BackendError error) {
+        super(error);
+    }
+
+    public static BackendTemplateException fromTemplateError(Backend.BackendError error) {
+
+        if (error.getLocalized() == null) {
+            return new BackendTemplateException(error);
+        }
+
+        if (error.getLocalized().contains("has a problem")) {
+            return new BackendTemplateSaveException(error);
+        }
+
+        return new BackendTemplateException(error);
+    }
+
+    public static class BackendTemplateSaveException extends BackendTemplateException {
+        public BackendTemplateSaveException(Backend.BackendError error) {
+            super(error);
+        }
+    }
+}


### PR DESCRIPTION
Convert each rust error into an appropriate Java error

This is likely flaky in 2.16 when we add in localization.
We're not getting good data for some errors and have to read the
exception message

Adds backend method to return each error: `debugProduceError`
This produces each error as the Rust would generate it
so we can unit test

Fixes #34
Fixes #35