### PR TITLE
feat: fix OOM via memory limit on DB row results

### DIFF
--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/DatabaseIntegrationTests.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/DatabaseIntegrationTests.java
@@ -23,7 +23,6 @@ import android.database.sqlite.SQLiteException;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
 import net.ankiweb.rsdroid.ankiutil.DatabaseUtil;
-import net.ankiweb.rsdroid.database.StreamingProtobufSQLiteCursor;
 import net.ankiweb.rsdroid.database.testutils.DatabaseComparison;
 
 import org.junit.Test;
@@ -38,6 +37,10 @@ import static org.junit.Assert.fail;
 @RunWith(Parameterized.class)
 public class DatabaseIntegrationTests extends DatabaseComparison {
 
+    private static final int INT_SIZE_BYTES = 8;
+    private static final int OPTIONAL_BYTES = 1;
+    /** Number of integers in 1 page of DB results when under test (111) */
+    public static int DB_PAGE_NUM_INT_ELEMENTS = TEST_PAGE_SIZE / (INT_SIZE_BYTES + OPTIONAL_BYTES);
 
     @Test
     public void testScalar() {
@@ -254,12 +257,12 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
 
         db.execSQL("create table test (id int)");
 
-        for (int i = 0; i < StreamingProtobufSQLiteCursor.RUST_PAGE_SIZE; i++) {
+        for (int i = 0; i < DB_PAGE_NUM_INT_ELEMENTS; i++) {
             db.execSQL("insert into test VALUES (1)");
         }
 
         try (Cursor c = db.query("select * from test")) {
-            assertThat(c.getCount(), is(StreamingProtobufSQLiteCursor.RUST_PAGE_SIZE));
+            assertThat(c.getCount(), is(DB_PAGE_NUM_INT_ELEMENTS));
         }
     }
 
@@ -269,12 +272,12 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
 
         db.execSQL("create table test (id int)");
 
-        for (int i = 0; i < StreamingProtobufSQLiteCursor.RUST_PAGE_SIZE + 1; i++) {
+        for (int i = 0; i < DB_PAGE_NUM_INT_ELEMENTS + 1; i++) {
             db.execSQL("insert into test VALUES (1)");
         }
 
         try (Cursor c = db.query("select * from test")) {
-            assertThat(c.getCount(), is(StreamingProtobufSQLiteCursor.RUST_PAGE_SIZE + 1));
+            assertThat(c.getCount(), is(DB_PAGE_NUM_INT_ELEMENTS + 1));
         }
     }
 

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ankiutil/InstrumentedTest.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ankiutil/InstrumentedTest.java
@@ -25,6 +25,8 @@ import androidx.test.platform.app.InstrumentationRegistry;
 import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.BackendUtils;
 import net.ankiweb.rsdroid.BackendV1;
+import net.ankiweb.rsdroid.BackendV1Impl;
+import net.ankiweb.rsdroid.NativeMethods;
 import net.ankiweb.rsdroid.RustBackendFailedException;
 
 import org.junit.After;
@@ -44,6 +46,8 @@ public class InstrumentedTest {
 
     private final List<BackendV1> backendList = new ArrayList<>();
 
+    protected final static int TEST_PAGE_SIZE = 1000;
+
     @Before
     public void before() {
         /*
@@ -51,6 +55,13 @@ public class InstrumentedTest {
         Timber.uprootAll();
         Timber.plant(new Timber.DebugTree());
         */
+
+        try {
+            NativeMethods.ensureSetup();
+        } catch (RustBackendFailedException e) {
+            throw new RuntimeException(e);
+        }
+        BackendV1Impl.setPageSize(TEST_PAGE_SIZE);
     }
 
     @After

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ankiutil/InstrumentedTest.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/ankiutil/InstrumentedTest.java
@@ -61,7 +61,7 @@ public class InstrumentedTest {
         } catch (RustBackendFailedException e) {
             throw new RuntimeException(e);
         }
-        BackendV1Impl.setPageSize(TEST_PAGE_SIZE);
+        BackendV1Impl.setPageSizeForTesting(TEST_PAGE_SIZE);
     }
 
     @After

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendMutex.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendMutex.java
@@ -178,6 +178,16 @@ public class BackendMutex implements BackendV1 {
         }
     }
 
+    @Override
+    public void setPageSize(long pageSizeBytes) {
+        try {
+            lock.lock();
+            backend.setPageSize(pageSizeBytes);
+        } finally {
+            lock.unlock();
+        }
+    }
+
     // RustBackend Implementation
 
     @Override

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendMutex.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendMutex.java
@@ -139,10 +139,10 @@ public class BackendMutex implements BackendV1 {
     }
 
     @Override
-    public Sqlite.DBResponse getPage(int page, int sequenceNumber) {
+    public Sqlite.DBResponse getNextSlice(long startIndex, int sequenceNumber) {
         try {
             lock.lock();
-            return backend.getPage(page, sequenceNumber);
+            return backend.getNextSlice(startIndex, sequenceNumber);
         } finally {
             lock.unlock();
         }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
@@ -18,6 +18,7 @@ package net.ankiweb.rsdroid;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 
@@ -270,13 +271,13 @@ public class BackendV1Impl extends net.ankiweb.rsdroid.RustBackendImpl implement
     }
 
     @Override
-    public Sqlite.DBResponse getPage(int page, int sequenceNumber) {
+    public Sqlite.DBResponse getNextSlice(long startIndex, int sequenceNumber) {
         byte[] result = null;
         try {
-            Timber.d("Rust: getPage %d", page);
+            Timber.d("Rust: getNextSlice %d", startIndex);
 
             Pointer backend = ensureBackend();
-            result = NativeMethods.databaseGetNextResultPage(backend.toJni(), sequenceNumber, page);
+            result = NativeMethods.databaseGetNextResultPage(backend.toJni(), sequenceNumber, startIndex);
 
             Sqlite.DBResponse message = Sqlite.DBResponse.parseFrom(result);
             validateMessage(result, message);
@@ -338,6 +339,12 @@ public class BackendV1Impl extends net.ankiweb.rsdroid.RustBackendImpl implement
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public static void setPageSize(long pageSizeInBytes) {
+        // TODO: Make this nonstatic
+        NativeMethods.setDbPageSize(pageSizeInBytes);
     }
 
 

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
@@ -342,11 +342,15 @@ public class BackendV1Impl extends net.ankiweb.rsdroid.RustBackendImpl implement
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public static void setPageSize(long pageSizeInBytes) {
+    public static void setPageSizeForTesting(long pageSizeInBytes) {
         // TODO: Make this nonstatic
         NativeMethods.setDbPageSize(pageSizeInBytes);
     }
 
+    @Override
+    public void setPageSize(long pageSizeInBytes) {
+        NativeMethods.setDbPageSize(pageSizeInBytes);
+    }
 
     @Override
     public String[] getColumnNames(String sql) {

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/NativeMethods.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/NativeMethods.java
@@ -72,7 +72,7 @@ public class NativeMethods {
     /** Returns the next page of results after a databaseCommand.
      * @return DbResult object */
     @CheckResult
-    static native byte[] databaseGetNextResultPage(long backendPointer, int sequenceNumber, int page);
+    static native byte[] databaseGetNextResultPage(long backendPointer, int sequenceNumber, long startIndex);
     
     /** Clears the memory from the current protobuf query. */
     static native int cancelCurrentProtoQuery(long backendPointer, int sequenceNumber);
@@ -97,6 +97,12 @@ public class NativeMethods {
     static native long closeBackend(long backendPointer);
 
     static native byte[] executeAnkiDroidCommand(long backendPointer, int command, byte[] args);
+
+    /**
+     * Sets the maximum number of bytes that a page of database results should return
+     * {@link net.ankiweb.rsdroid.database.StreamingProtobufSQLiteCursor}
+     */
+    static native void setDbPageSize(long numberOfBytes);
 
     /**
      * Produces all possible Rust-based errors.

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/SQLHandler.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/SQLHandler.java
@@ -41,7 +41,7 @@ public interface SQLHandler {
     String getPath();
 
     /* Protobuf-related (#6) */
-    Sqlite.DBResponse getPage(int page, int sequenceNumber);
+    Sqlite.DBResponse getNextSlice(long startIndex, int sequenceNumber);
     Sqlite.DBResponse fullQueryProto(String query, Object... bindArgs);
 
     void cancelCurrentProtoQuery(int sequenceNumber);

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/SQLHandler.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/SQLHandler.java
@@ -46,4 +46,14 @@ public interface SQLHandler {
 
     void cancelCurrentProtoQuery(int sequenceNumber);
     void cancelAllProtoQueries();
+
+    /**
+     * Sets the page size for all future calls to
+     * {@link SQLHandler#getNextSlice(long, int)}
+     * and
+     * {@link SQLHandler#fullQueryProto(String, Object...)}
+     *
+     * Default: 2MB
+     */
+    void setPageSize(long pageSizeBytes);
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/Session.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/Session.java
@@ -105,6 +105,11 @@ public class Session implements SQLHandler {
         backend.cancelAllProtoQueries();
     }
 
+    @Override
+    public void setPageSize(long pageSizeBytes) {
+        backend.setPageSize(pageSizeBytes);
+    }
+
 
     public void setTransactionSuccessful() {
         if (!inTransaction()) {

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/Session.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/Session.java
@@ -86,8 +86,8 @@ public class Session implements SQLHandler {
     }
 
     @Override
-    public Sqlite.DBResponse getPage(int page, int sequenceNumber) {
-        return backend.getPage(page, sequenceNumber);
+    public Sqlite.DBResponse getNextSlice(long startIndex, int sequenceNumber) {
+        return backend.getNextSlice(startIndex, sequenceNumber);
     }
 
     @Override

--- a/rslib-bridge/Cargo.lock
+++ b/rslib-bridge/Cargo.lock
@@ -868,6 +868,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,7 +1407,7 @@ name = "rsdroid"
 version = "0.1.0"
 dependencies = [
  "anki",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "jni",
  "lazy_static",
  "num_enum",

--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0.56"
 serde_derive = "1.0.114"
 lazy_static = "1.4.0"
 num_enum = "0.5.0"
-itertools = "0.9.0"
+itertools = "0.10.0"
 
 # picked bundled - TODO: Is this correct?
 rusqlite = { version = "0.23.1", features = ["trace", "functions", "collation", "bundled"] }

--- a/rslib-bridge/src/dbcommand.rs
+++ b/rslib-bridge/src/dbcommand.rs
@@ -12,7 +12,72 @@ use anki::backend_proto::{DbResponse, DbResult};
 use i64 as backend_pointer;
 use i64 as dbresponse_pointer;
 
-use itertools::Itertools;
+use anki::backend_proto::{Row, SqlValue};
+use std::mem::size_of;
+use anki::backend_proto::sql_value::Data;
+use itertools::{Itertools, FoldWhile};
+use itertools::FoldWhile::{Done, Continue};
+use std::ops::Deref;
+
+
+pub trait Sizable {
+    /** Estimates the heap size of the value, in bytes */
+    fn estimate_size(&self) -> usize;
+}
+
+impl Sizable for Data {
+    fn estimate_size(&self) -> usize {
+        match self {
+            Data::StringValue(s) => { s.len() }
+            Data::LongValue(_) => { size_of::<i64>() }
+            Data::DoubleValue(_) => { size_of::<f64>() }
+            Data::BlobValue(b) => { b.len() }
+        }
+    }
+}
+
+impl Sizable for SqlValue {
+    fn estimate_size(&self) -> usize {
+        // Add a byte for the optional
+        self.data.as_ref().map(|f| f.estimate_size() + 1).unwrap_or(1)
+    }
+}
+
+impl Sizable for Row {
+    fn estimate_size(&self) -> usize {
+        self.fields.iter().map(|x| x.estimate_size()).sum()
+    }
+}
+
+impl Sizable for DbResult {
+    fn estimate_size(&self) -> usize {
+        // Performance: It might be best to take the first x rows and determine the data types
+        // If we have floats or longs, they'll be a fixed size (excluding nulls) and should speed
+        // up the calculation as we'll only calculate a subset of the columns.
+        self.rows.iter().map(|x| x.estimate_size()).sum()
+    }
+}
+
+pub(crate) fn select_next_slice<'a>(mut rows : impl Iterator<Item = &'a Row>) -> Vec<Row> {
+    select_slice_of_size(rows, get_max_page_size()).into_inner().1
+}
+
+fn select_slice_of_size<'a>(mut rows : impl Iterator<Item = &'a Row>, max_size: usize) -> FoldWhile<(usize, Vec<Row>)> {
+    let init: Vec<Row> = Vec::new();
+    let folded = rows.fold_while((0, init), |mut acc, x| {
+        let new_size = acc.0 + x.estimate_size();
+        // If the accumulator is 0, but we're over the size: return a single result so we don't loop forever.
+        // Theoretically, this shouldn't happen as data should be reasonably sized
+        if new_size > max_size && acc.0 > 0 {
+            Done(acc)
+        } else {
+            // PERF: should be faster to return (size, numElements) then bulk copy/slice
+            acc.1.push(x.to_owned());
+            Continue((new_size, acc.1))
+        }
+    });
+    folded
+}
 
 lazy_static! {
     // backend_pointer => Map<sequenceNumber, DbResponse pointer>
@@ -72,7 +137,28 @@ pub(crate) fn active_sequences(ptr : backend_pointer) -> Vec<i32> {
     }
 }
 
-pub(crate) fn insert_cache(ptr : backend_pointer, result : DbResponse) {
+/**
+Store the data in the cache if larger than than the page size.<br/>
+Returns: The data capped to the page size
+*/
+pub(crate) fn trim_and_cache_remaining(backend_ptr: i64, values: DbResult, sequence_number: i32) -> DbResponse {
+    let start_index = 0;
+
+    // PERF: Could speed this up by not creating the vector and just calculating the count
+    let first_result = select_next_slice(values.rows.iter());
+
+    let row_count = values.rows.len() as i32;
+    if first_result.len() < values.rows.len() {
+        let to_store = DbResponse { result: Some(values), sequence_number, row_count, start_index };
+        insert_cache(backend_ptr, to_store);
+
+        DbResponse { result: Some(DbResult { rows: first_result }), sequence_number, row_count, start_index }
+    } else {
+        DbResponse { result: Some(values), sequence_number, row_count, start_index }
+    }
+}
+
+fn insert_cache(ptr : backend_pointer, result : DbResponse) {
     let mut map = HASHMAP.lock().unwrap();
 
     match map.get_mut(&ptr) {
@@ -88,7 +174,22 @@ pub(crate) fn insert_cache(ptr : backend_pointer, result : DbResponse) {
     out_hash_map.insert(result.sequence_number,  Box::into_raw(Box::new(result)) as dbresponse_pointer);
 }
 
-pub(crate) unsafe fn get_next(ptr : backend_pointer, sequence_number : i32, offset : usize, to_take : usize) -> Option<DbResponse> {
+pub(crate) unsafe fn get_next(ptr : backend_pointer, sequence_number : i32, start_index : i64) -> Option<DbResponse> {
+    let result = get_next_result(ptr, &sequence_number, start_index);
+
+    match result.as_ref() {
+        Some(x) => {
+            if x.result.is_none() || x.result.as_ref().unwrap().rows.is_empty() {
+                flush_cache(&ptr, sequence_number)
+            }
+        },
+        None => {}
+    }
+
+    result
+}
+
+unsafe fn get_next_result(ptr: backend_pointer, sequence_number: &i32, start_index: i64) -> Option<DbResponse> {
     let map = HASHMAP.lock().unwrap();
 
     let result_map = map.get(&ptr)?;
@@ -97,13 +198,18 @@ pub(crate) unsafe fn get_next(ptr : backend_pointer, sequence_number : i32, offs
 
     let current_result = &mut *(backend_ptr as *mut DbResponse);
 
-    let result = DbResult { rows: current_result.result.as_ref().unwrap_or(&DbResult { rows: Vec::new()} ).rows.iter().skip(offset).take(to_take).cloned().collect() };
+    // TODO: This shouldn't need to exist
+    let tmp: Vec<Row> = Vec::new();
+    let next_rows = current_result.result.as_ref().map(|x| x.rows.iter()).unwrap_or(tmp.iter());
 
-    if result.rows.is_empty() {
-        flush_cache(&ptr, sequence_number)
-    }
+    let skipped_rows = next_rows.clone().skip(start_index as usize).collect_vec();
+    println!("{}", skipped_rows.len());
 
-    let trimmed_result = DbResponse { result: Some(result), sequence_number: current_result.sequence_number, row_count: current_result.row_count };
+    let filtered_rows = select_next_slice(next_rows.skip(start_index as usize));
+
+    let result = DbResult { rows: filtered_rows };
+
+    let trimmed_result = DbResponse { result: Some(result), sequence_number: current_result.sequence_number, row_count: current_result.row_count, start_index };
 
     Some(trimmed_result)
 }
@@ -113,4 +219,132 @@ static mut SEQUENCE_NUMBER: i32 = 0;
 pub(crate) unsafe fn next_sequence_number() -> i32 {
     SEQUENCE_NUMBER = SEQUENCE_NUMBER + 1;
     SEQUENCE_NUMBER
+}
+
+lazy_static!{
+    // same as we get from io.requery.android.database.CursorWindow.sCursorWindowSize
+    static ref DB_COMMAND_PAGE_SIZE: Mutex<usize> = Mutex::new(1024 * 1024 * 2);
+}
+
+pub(crate) fn set_max_page_size(size: usize) {
+    let mut state = DB_COMMAND_PAGE_SIZE.lock().expect("Could not lock mutex");
+    *state = size;
+}
+
+fn get_max_page_size() -> usize {
+    *DB_COMMAND_PAGE_SIZE.lock().unwrap()
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anki::backend_proto::{sql_value, Row, SqlValue};
+    use crate::dbcommand::{Sizable, select_slice_of_size};
+    use std::borrow::Borrow;
+
+    fn gen_data() -> Vec<SqlValue> {
+        vec![
+            SqlValue{
+                data: Some(sql_value::Data::DoubleValue(12.0))
+            },
+            SqlValue{
+                data: Some(sql_value::Data::LongValue(12))
+            },
+            SqlValue{
+                data: Some(sql_value::Data::StringValue("Hellooooooo World".to_string()))
+            },
+            SqlValue{
+                data: Some(sql_value::Data::BlobValue(vec![]))
+            }
+        ]
+    }
+
+    #[test]
+    fn test_size_estimate() {
+        let row = Row { fields: gen_data() };
+        let result = DbResult { rows: vec![row.clone(), row.clone()] };
+
+        let actual_size = result.estimate_size();
+
+        let expected_size = (17 + 8 + 8) * 2; // 1 variable string, 1 long, 1 float
+        let expected_overhead = (4 * 1) * 2; // 4 optional columns
+
+        assert_eq!(actual_size, expected_overhead + expected_size);
+    }
+
+    #[test]
+    fn test_stream_size() {
+        let row = Row { fields: gen_data() };
+        let result = DbResult { rows: vec![row.clone(), row.clone(), row.clone()] };
+        let limit = 74 + 1; // two rows are 74
+
+        let result = select_slice_of_size(result.rows.iter(), limit).into_inner();
+
+        assert_eq!(2, result.1.len(), "The final element should not be included");
+        assert_eq!(74, result.0, "The size should be the size of the first two objects");
+    }
+
+    #[test]
+    fn test_stream_size_too_small() {
+        let row = Row { fields: gen_data() };
+        let result = DbResult { rows: vec![row.clone()] };
+        let limit = 1;
+
+        let result = select_slice_of_size(result.rows.iter(), limit).into_inner();
+
+        assert_eq!(1, result.1.len(), "If the limit is too small, a result is still returned");
+        assert_eq!(37, result.0, "The size should be the size of the first objects");
+    }
+
+    const BACKEND_PTR: i64 = 12;
+    const SEQUENCE_NUMBER: i32 = 1;
+
+    fn get(index : i64) -> Option<DbResponse> {
+        unsafe { return get_next(BACKEND_PTR, SEQUENCE_NUMBER, index) };
+    }
+
+    fn get_first(result : DbResult) -> DbResponse {
+        trim_and_cache_remaining(BACKEND_PTR, result, SEQUENCE_NUMBER)
+    }
+
+    fn seq_number_used() -> bool {
+        HASHMAP.lock().unwrap().get(&BACKEND_PTR).unwrap().contains_key(&SEQUENCE_NUMBER)
+    }
+
+    #[test]
+    fn integration_test() {
+        let row = Row { fields: gen_data() };
+
+        // return one row at a time
+        set_max_page_size(row.estimate_size() - 1);
+
+        let db_query_result = DbResult { rows: vec![row.clone(), row.clone()] };
+
+        let first_jni_response = get_first(db_query_result);
+
+        assert_eq!(row_count(&first_jni_response), 1, "The first call should only return one row");
+
+        let next_index = first_jni_response.start_index + row_count(&first_jni_response);
+
+        let second_response = get(next_index);
+
+        assert!(second_response.is_some(), "The second response should return a value");
+        let valid_second_response = second_response.unwrap();
+        assert_eq!(row_count(&valid_second_response), 1);
+
+        let final_index = valid_second_response.start_index + row_count(&valid_second_response);
+
+        assert!(seq_number_used(), "The sequence number is assigned");
+
+        let final_response = get(final_index);
+        assert!(final_response.is_some(), "The third call should return something with no rows");
+        assert_eq!(row_count(&final_response.unwrap()), 0, "The third call should return something with no rows");
+        assert!(!seq_number_used(), "Sequence number data has been cleared");
+    }
+
+    fn row_count(resp: &DbResponse) -> i64 {
+        resp.result.as_ref().map(|x| x.rows.len()).unwrap_or(0) as i64
+    }
 }


### PR DESCRIPTION
We now use a 2MB page size, the same as CursorWindow.sCursorWindowSize

We occasionally got OOMs on methods which returned unbounded data
eg. getting the field data for notes: "Check Database" crashed

To fix this, instead of saying to the Rust "we want 1000 rows max",
we say "we want max 2MB of data"

The calculation for the data is inexact - string length, and 8 bytes
for doubles/longs.
Hasn't been tested thoroughly, but seems to only be < ~7%
off the protobuf size for a string-only column (underestimate).

We measure the rust in-memory usage rather than the size of the
serialized protobuf

Measuring the serialized size wasn't researched, but was assumed to be
hard, as we would need to stream into a protobuf collection, and be
able to efficiently query the new size for each row we add.

Main changes:
StreamingProtobufSQLiteCursor - no longer use fixed size pages
dbcommand: allow access via an offset to the result set rather than
via pages

Adds: setDbPageSize to allow the change of the size for debugging
Adds: Unit tests for the rust - not yet executed in CI (#51)
rename: getPage -> getNextSlice

bumps `anki` commit to add field sqlite.proto#DbResponse:start_index

Fixes #14 (no longer necessary)
Fixes https://github.com/ankidroid/Anki-Android/issues/8178