### PR TITLE
feat[ci]: Test javadoc generation

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -55,3 +55,7 @@ jobs:
 
     - name: Build
       run: ./gradlew clean assembleRelease -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain # assembleAndroidTest
+
+    # Our publish workflow (publish_library.yaml) in on Ubuntu and needs javadocs (#57)
+    - name: Test Javadoc
+      run: ./gradlew :rsdroid:androidJavadocs -DtestBuildType=release -Dorg.gradle.daemon=false -Dorg.gradle.console=plain


### PR DESCRIPTION
Our publish workflow creates javadocs, this failed due to an
environment change, and was not tested

So perform this test on every commit & on schedule

Fixes #57