### PR TITLE
fix[CI]: update Lexical core

### DIFF
--- a/rslib-bridge/Cargo.toml
+++ b/rslib-bridge/Cargo.toml
@@ -19,6 +19,7 @@ serde_derive = "1.0.114"
 lazy_static = "1.4.0"
 num_enum = "0.5.0"
 itertools = "0.10.0"
+lexical-core = "0.7.5"
 
 # picked bundled - TODO: Is this correct?
 rusqlite = { version = "0.23.1", features = ["trace", "functions", "collation", "bundled"] }


### PR DESCRIPTION
0.7.4 is incompatible with Rust nightlies

```
error[E0277]: cannot subtract `usize` from `u32`
    --> lexical-core-0.7.4/src/atof/algorithm/math.rs:2065:25
     |
2065 |     let rs = Limb::BITS - s;
     |                         ^ no implementation for `u32 - usize`
     |
     = help: the trait `Sub<usize>` is not implemented for `u32`
 ```