### PR TITLE
DatabaseCursor: Implement ContentProvider methods

### DIFF
--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.java
@@ -99,9 +99,7 @@ public abstract class AnkiDatabaseCursor implements Cursor {
     public abstract boolean isClosed();
 
     @Override
-    public int getType(int columnIndex) {
-        throw new NotImplementedException();
-    }
+    public abstract int getType(int columnIndex);
 
     @Override
     public byte[] getBlob(int columnIndex) {
@@ -115,6 +113,7 @@ public abstract class AnkiDatabaseCursor implements Cursor {
 
     @Override
     public void deactivate() {
+        Timber.w("deactivate - not implemented - throwing");
         throw new NotImplementedException();
     }
 
@@ -125,6 +124,7 @@ public abstract class AnkiDatabaseCursor implements Cursor {
 
     @Override
     public boolean requery() {
+        Timber.w("requery - not implemented - throwing");
         throw new NotImplementedException();
     }
 
@@ -155,7 +155,7 @@ public abstract class AnkiDatabaseCursor implements Cursor {
 
     @Override
     public boolean moveToPosition(int position) {
-        return false;
+        return move(position - getPosition());
     }
 
     @Override
@@ -190,17 +190,27 @@ public abstract class AnkiDatabaseCursor implements Cursor {
 
     @Override
     public boolean isLast() {
-        throw new NotImplementedException();
+        return getPosition() == getCount() - 1;
     }
-
 
     @Override
     public boolean isAfterLast() {
-        throw new NotImplementedException();
+        return getPosition() >= getCount();
     }
 
     @Override
     public boolean move(int offset) {
-        throw new NotImplementedException();
+        if (offset < 0) {
+            Timber.w("Negative moves are not supported");
+            return false;
+        }
+        while (offset > 0) {
+            if (!moveToNext()) {
+                return false;
+            }
+            offset--;
+        }
+
+        return true;
     }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiJsonDatabaseCursor.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiJsonDatabaseCursor.java
@@ -190,4 +190,9 @@ public abstract class AnkiJsonDatabaseCursor extends AnkiDatabaseCursor {
     protected JSONArray fullQuery(String query, Object[] bindArgs) {
         return backend.fullQuery(query, bindArgs);
     }
+
+    @Override
+    public int getType(int columnIndex) {
+        throw new NotImplementedException();
+    }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/StreamingProtobufSQLiteCursor.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/StreamingProtobufSQLiteCursor.java
@@ -243,6 +243,19 @@ public class StreamingProtobufSQLiteCursor extends AnkiDatabaseCursor {
         return isClosed;
     }
 
+    @Override
+    public int getType(int columnIndex) {
+        Sqlite.SqlValue field = getFieldAtIndex(columnIndex);
+        switch (field.getDataCase()) {
+            case BLOBVALUE: return FIELD_TYPE_BLOB;
+            case LONGVALUE: return FIELD_TYPE_INTEGER;
+            case DOUBLEVALUE: return FIELD_TYPE_FLOAT;
+            case STRINGVALUE: return FIELD_TYPE_STRING;
+            case DATA_NOT_SET: return FIELD_TYPE_NULL;
+            default: throw new IllegalStateException("Unknown data case: " + field.getDataCase());
+        }
+    }
+
     protected Sqlite.Row getRowAtCurrentPosition() {
         Sqlite.DBResult result = results.getResult();
         int rowCount = getCurrentSliceRowCount();


### PR DESCRIPTION
Our ContentProvider/API implementation used:

`android.database.CursorToBulkCursorAdaptor`
and `DatabaseUtils.cursorFillWindow`

These called through to `moveToPosition` and `getType`
which were not implemented.

Fix this by implementing the methods