### PR TITLE
DB Cursors: allow moving backwards 

### DIFF
--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/DatabaseIntegrationTests.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/DatabaseIntegrationTests.java
@@ -31,6 +31,7 @@ import org.junit.runners.Parameterized;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
@@ -173,7 +174,8 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
         try {
             testStringConversion("byte", "?");
         } catch (SQLiteException e) {
-           assertThat(e.getMessage(), is("unknown error (code 0): Unable to convert BLOB to string"));
+           assertThat(e.getMessage(), isOneOf("unknown error (code 0): Unable to convert BLOB to string",
+                   "unknown error (code 0 SQLITE_OK): Unable to convert BLOB to string"));
         }
     }
 
@@ -190,7 +192,8 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
         try {
             testIntConversion("byte", 42);
         } catch (SQLiteException e) {
-            assertThat(e.getMessage(), is("unknown error (code 0): Unable to convert BLOB to long"));
+            assertThat(e.getMessage(), isOneOf("unknown error (code 0): Unable to convert BLOB to long",
+                    "unknown error (code 0 SQLITE_OK): Unable to convert BLOB to long"));
         }
     }
 
@@ -207,7 +210,8 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
         try {
             testFloatConversion("byte", 42);
         } catch (SQLiteException e) {
-            assertThat(e.getMessage(), is("unknown error (code 0): Unable to convert BLOB to double"));
+            assertThat(e.getMessage(), isOneOf("unknown error (code 0): Unable to convert BLOB to double",
+                    "unknown error (code 0 SQLITE_OK): Unable to convert BLOB to double"));
         }
     }
 
@@ -224,7 +228,8 @@ public class DatabaseIntegrationTests extends DatabaseComparison {
         try {
             testDoubleConversion("byte", 42);
         } catch (SQLiteException e) {
-            assertThat(e.getMessage(), is("unknown error (code 0): Unable to convert BLOB to double"));
+            assertThat(e.getMessage(), isOneOf("unknown error (code 0): Unable to convert BLOB to double",
+                    "unknown error (code 0 SQLITE_OK): Unable to convert BLOB to double"));
         }
     }
 

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/AnkiDatabaseCursor.java
@@ -51,12 +51,6 @@ public abstract class AnkiDatabaseCursor implements Cursor {
     public abstract int getPosition();
 
     @Override
-    public abstract boolean moveToFirst();
-
-    @Override
-    public abstract boolean moveToNext();
-
-    @Override
     public abstract int getColumnIndex(String columnName);
 
     @Override
@@ -154,9 +148,7 @@ public abstract class AnkiDatabaseCursor implements Cursor {
     }
 
     @Override
-    public boolean moveToPosition(int position) {
-        return move(position - getPosition());
-    }
+    public abstract boolean moveToPosition(int position);
 
     @Override
     public void registerContentObserver(ContentObserver observer) {
@@ -178,19 +170,10 @@ public abstract class AnkiDatabaseCursor implements Cursor {
         Timber.w("Not implemented: unregisterDataSetObserver - shouldn't matter unless requery() is called");
     }
 
-    @Override
-    public boolean moveToLast() {
-        throw new NotImplementedException();
-    }
-
-    @Override
-    public boolean moveToPrevious() {
-        throw new NotImplementedException();
-    }
 
     @Override
     public boolean isLast() {
-        return getPosition() == getCount() - 1;
+        return getPosition() == getLastPosition();
     }
 
     @Override
@@ -200,17 +183,33 @@ public abstract class AnkiDatabaseCursor implements Cursor {
 
     @Override
     public boolean move(int offset) {
-        if (offset < 0) {
-            Timber.w("Negative moves are not supported");
-            return false;
-        }
-        while (offset > 0) {
-            if (!moveToNext()) {
-                return false;
-            }
-            offset--;
-        }
+        return moveToPosition(getPosition() + offset);
+    }
 
-        return true;
+    @Override
+    public boolean moveToLast() {
+        int toMoveTo = getLastPosition();
+        return moveToPosition(toMoveTo);
+    }
+
+    @Override
+    public boolean moveToFirst() {
+        return moveToPosition(0);
+    }
+
+    @Override
+    public boolean moveToNext() {
+        int toMoveTo = getPosition() + 1;
+        return moveToPosition(toMoveTo);
+    }
+
+    @Override
+    public boolean moveToPrevious() {
+        int toMoveTo = getPosition() - 1;
+        return moveToPosition(toMoveTo);
+    }
+
+    protected int getLastPosition() {
+        return getCount() - 1;
     }
 }


### PR DESCRIPTION
We should support this, as resetting the cursor is required by `DatabaseUtils.cursorFillWindow`, which triggered issues with API clients

Note: Inefficient on `moveToPrevious`, but I don't see this as a common case