### PR TITLE
Add BackendVNextFactory and support classes

### DIFF
--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendDisposalTests.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendDisposalTests.java
@@ -16,14 +16,12 @@
 
 package net.ankiweb.rsdroid;
 
-import android.util.Log;
-
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import net.ankiweb.rsdroid.ankiutil.InstrumentedTest;
 import net.ankiweb.rsdroid.ankiutil.DatabaseUtil;
-import net.ankiweb.rsdroid.database.RustSupportSQLiteOpenHelper;
+import net.ankiweb.rsdroid.ankiutil.InstrumentedTest;
+import net.ankiweb.rsdroid.database.RustV11SupportSQLiteOpenHelper;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,7 +42,7 @@ public class BackendDisposalTests extends InstrumentedTest {
 
             Timber.d("Iteration %d", i);
             try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-                SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+                SupportSQLiteDatabase db = new RustV11SupportSQLiteOpenHelper(backend).getWritableDatabase();
 
                 int count = DatabaseUtil.queryScalar(db, "select count(*) from revlog");
             }

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendSlowTests.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/BackendSlowTests.java
@@ -21,7 +21,7 @@ import android.database.Cursor;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 
 import net.ankiweb.rsdroid.ankiutil.InstrumentedTest;
-import net.ankiweb.rsdroid.database.RustSupportSQLiteOpenHelper;
+import net.ankiweb.rsdroid.database.RustV11SupportSQLiteOpenHelper;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -142,7 +142,7 @@ public class BackendSlowTests extends InstrumentedTest {
          */
 
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = new RustV11SupportSQLiteOpenHelper(backend).getWritableDatabase();
 
             db.query("create table tmp (id varchar)");
 

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/database/StreamingProtobufSQLiteCursorTest.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/database/StreamingProtobufSQLiteCursorTest.java
@@ -41,7 +41,7 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
     public void testPaging() throws IOException {
 
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id int)");
 
@@ -61,11 +61,15 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
         }
     }
 
+    private SupportSQLiteDatabase getWritableDatabase(BackendV1 backend) {
+        return new RustV11SupportSQLiteOpenHelper(backend).getWritableDatabase();
+    }
+
     @Test
     public void testBackwards() throws IOException {
         Timber.w("This is much slower than forwards");
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id int)");
 
@@ -96,7 +100,7 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
     @Test
     public void moveToPositionStart() throws IOException {
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id int)");
 
@@ -152,7 +156,7 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
        int elements = DatabaseIntegrationTests.DB_PAGE_NUM_INT_ELEMENTS;
 
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id int)");
             for (int i = 0; i < elements + 1; i++) {
@@ -190,7 +194,7 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
 
 
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id varchar)");
             for (int i = 0; i < elements + 1; i++) {
@@ -216,7 +220,7 @@ public class StreamingProtobufSQLiteCursorTest extends InstrumentedTest {
         int elements = 50; // 1275 > 1000
 
         try (BackendV1 backend = super.getBackend("initial_version_2_12_1.anki2")) {
-            SupportSQLiteDatabase db = new RustSupportSQLiteOpenHelper(backend).getWritableDatabase();
+            SupportSQLiteDatabase db = getWritableDatabase(backend);
 
             db.execSQL("create table tmp (id varchar)");
             for (int i = 0; i < elements + 1; i++) {

--- a/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/database/testutils/DatabaseComparison.java
+++ b/rsdroid-instrumented/src/androidTest/java/net/ankiweb/rsdroid/database/testutils/DatabaseComparison.java
@@ -24,7 +24,7 @@ import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.ankiutil.InstrumentedTest;
 import net.ankiweb.rsdroid.RustBackendFailedException;
-import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
+import net.ankiweb.rsdroid.database.RustV11SQLiteOpenHelperFactory;
 
 import org.junit.Before;
 import org.junit.runners.Parameterized;
@@ -74,7 +74,7 @@ public class DatabaseComparison extends InstrumentedTest {
                     throw new RuntimeException(e);
                 }
                 // This throws on corruption
-                return new RustSQLiteOpenHelperFactory(mBackendFactory).create(config).getWritableDatabase();
+                return new RustV11SQLiteOpenHelperFactory(mBackendFactory).create(config).getWritableDatabase();
             case FRAMEWORK:
                 return new FrameworkSQLiteOpenHelperFactory().create(config).getWritableDatabase();
         }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.java
@@ -16,6 +16,10 @@
 
 package net.ankiweb.rsdroid;
 
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+
+import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
+
 public class BackendFactory {
 
     private BackendV1 backend;
@@ -49,5 +53,9 @@ public class BackendFactory {
 
         // we could swallow the exception here, most of the time it will be "collection is already closed"
         backend.closeCollection(false);
+    }
+    
+    public SupportSQLiteOpenHelper.Factory getSQLiteOpener() {
+        return new RustSQLiteOpenHelperFactory(this);
     }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendFactory.java
@@ -18,9 +18,7 @@ package net.ankiweb.rsdroid;
 
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
-import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
-
-public class BackendFactory {
+public abstract class BackendFactory {
 
     private BackendV1 backend;
 
@@ -29,14 +27,9 @@ public class BackendFactory {
 
     }
 
-    /**
-     * Obtains an instance of BackendFactory which will connect to rsdroid.
-     * Each call will generate a separate instance which can handle a new Anki collection
-     */
-    @RustV1Cleanup("RustBackendFailedException may be moved to a more appropriate location")
+    @RustCleanup("Use BackendV[11/Next]Factory")
     public static BackendFactory createInstance() throws RustBackendFailedException {
-        NativeMethods.ensureSetup();
-        return new BackendFactory();
+        return BackendV11Factory.createInstance();
     }
 
     public synchronized BackendV1 getBackend() {
@@ -55,7 +48,5 @@ public class BackendFactory {
         backend.closeCollection(false);
     }
     
-    public SupportSQLiteOpenHelper.Factory getSQLiteOpener() {
-        return new RustSQLiteOpenHelperFactory(this);
-    }
+    public abstract SupportSQLiteOpenHelper.Factory getSQLiteOpener();
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV11Factory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV11Factory.java
@@ -18,8 +18,7 @@ package net.ankiweb.rsdroid;
 
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
-import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
-import net.ankiweb.rsdroid.database.RustV16SQLiteOpenHelperFactory;
+import net.ankiweb.rsdroid.database.RustV11SQLiteOpenHelperFactory;
 
 public class BackendV11Factory extends BackendFactory {
 
@@ -34,6 +33,6 @@ public class BackendV11Factory extends BackendFactory {
     }
 
     public SupportSQLiteOpenHelper.Factory getSQLiteOpener() {
-        return new RustSQLiteOpenHelperFactory(this);
+        return new RustV11SQLiteOpenHelperFactory(this);
     }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV11Factory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV11Factory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid;
+
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+
+import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
+import net.ankiweb.rsdroid.database.RustV16SQLiteOpenHelperFactory;
+
+public class BackendV11Factory extends BackendFactory {
+
+    /**
+     * Obtains an instance of BackendFactory which will connect to rsdroid.
+     * Each call will generate a separate instance which can handle a new Anki collection
+     */
+    @RustV1Cleanup("RustBackendFailedException may be moved to a more appropriate location")
+    public static BackendV11Factory createInstance() throws RustBackendFailedException {
+        NativeMethods.ensureSetup();
+        return new BackendV11Factory();
+    }
+
+    public SupportSQLiteOpenHelper.Factory getSQLiteOpener() {
+        return new RustSQLiteOpenHelperFactory(this);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendV1Impl.java
@@ -139,18 +139,6 @@ public class BackendV1Impl extends net.ankiweb.rsdroid.RustBackendImpl implement
         }
     }
 
-    // the main openCollection does an upgrade to V15, which is not ideal
-    @Override
-    public void openCollection(@Nullable String collectionPath, @Nullable String mediaFolderPath, @Nullable String mediaDbPath, @Nullable String logPath) {
-        Backend.OpenCollectionIn in = Backend.OpenCollectionIn.newBuilder()
-                .setCollectionPath(collectionPath)
-                .setMediaFolderPath(mediaFolderPath)
-                .setMediaDbPath(mediaDbPath)
-                .setLogPath(logPath)
-                .build();
-        openAnkiDroidCollection(in);
-    }
-
     @CheckResult
     public JSONArray fullQuery(String sql, @Nullable Object... args) {
         try {

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendVNextFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/BackendVNextFactory.java
@@ -18,44 +18,22 @@ package net.ankiweb.rsdroid;
 
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
-import net.ankiweb.rsdroid.database.RustSQLiteOpenHelperFactory;
+import net.ankiweb.rsdroid.database.RustVNextSQLiteOpenHelperFactory;
 
-public class BackendFactory {
-
-    private BackendV1 backend;
-
-    // Force users to go through getInstance - for now we need to handle the backend failure
-    protected BackendFactory() {
-
-    }
+/** A factory for the latest version of the backend (v16 currently) */
+public class BackendVNextFactory extends BackendFactory {
 
     /**
      * Obtains an instance of BackendFactory which will connect to rsdroid.
      * Each call will generate a separate instance which can handle a new Anki collection
      */
     @RustV1Cleanup("RustBackendFailedException may be moved to a more appropriate location")
-    public static BackendFactory createInstance() throws RustBackendFailedException {
+    public static BackendVNextFactory createInstance() throws RustBackendFailedException {
         NativeMethods.ensureSetup();
-        return new BackendFactory();
+        return new BackendVNextFactory();
     }
 
-    public synchronized BackendV1 getBackend() {
-        if (backend == null) {
-            backend = new BackendMutex(new BackendV1Impl());
-        }
-        return backend;
-    }
-
-    public synchronized void closeCollection() {
-        if (backend == null) {
-            return;
-        }
-
-        // we could swallow the exception here, most of the time it will be "collection is already closed"
-        backend.closeCollection(false);
-    }
-    
     public SupportSQLiteOpenHelper.Factory getSQLiteOpener() {
-        return new RustSQLiteOpenHelperFactory(this);
+        return new RustVNextSQLiteOpenHelperFactory(this);
     }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSQLiteOpenHelperFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSQLiteOpenHelperFactory.java
@@ -34,6 +34,6 @@ public class RustSQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Fact
     @NonNull
     @Override
     public SupportSQLiteOpenHelper create(@NonNull SupportSQLiteOpenHelper.Configuration configuration) {
-        return new RustSupportSQLiteOpenHelper(configuration, backendFactory);
+        return new RustV11SupportSQLiteOpenHelper(configuration, backendFactory);
     }
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSupportSQLiteOpenHelper.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSupportSQLiteOpenHelper.java
@@ -33,7 +33,7 @@ public class RustSupportSQLiteOpenHelper implements SupportSQLiteOpenHelper {
     @Nullable
     private final BackendV1 backend;
     private BackendFactory backendFactory;
-    private RustSupportSQLiteDatabase database;
+    private SupportSQLiteDatabase database;
 
     public RustSupportSQLiteOpenHelper(@NonNull Configuration configuration, BackendFactory backendFactory) {
         this.configuration = configuration;
@@ -84,7 +84,7 @@ public class RustSupportSQLiteOpenHelper implements SupportSQLiteOpenHelper {
 
     }
 
-    private RustSupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly) {
+    private SupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly) {
         Timber.d("createRustSupportSQLiteDatabase");
         if (configuration != null) {
             BackendV1 backend = backendFactory.getBackend();

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSupportSQLiteOpenHelper.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustSupportSQLiteOpenHelper.java
@@ -22,18 +22,15 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteOpenHelper;
 
 import net.ankiweb.rsdroid.BackendFactory;
-import net.ankiweb.rsdroid.BackendUtils;
 import net.ankiweb.rsdroid.BackendV1;
 
-import timber.log.Timber;
-
-public class RustSupportSQLiteOpenHelper implements SupportSQLiteOpenHelper {
+public abstract class RustSupportSQLiteOpenHelper implements SupportSQLiteOpenHelper {
     @Nullable
-    private final Configuration configuration;
+    protected final Configuration configuration;
     @Nullable
-    private final BackendV1 backend;
-    private BackendFactory backendFactory;
-    private SupportSQLiteDatabase database;
+    protected final BackendV1 backend;
+    protected BackendFactory backendFactory;
+    protected SupportSQLiteDatabase database;
 
     public RustSupportSQLiteOpenHelper(@NonNull Configuration configuration, BackendFactory backendFactory) {
         this.configuration = configuration;
@@ -84,14 +81,5 @@ public class RustSupportSQLiteOpenHelper implements SupportSQLiteOpenHelper {
 
     }
 
-    private SupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly) {
-        Timber.d("createRustSupportSQLiteDatabase");
-        if (configuration != null) {
-            BackendV1 backend = backendFactory.getBackend();
-            BackendUtils.openAnkiDroidCollection(backend, configuration.name);
-            return new RustSupportSQLiteDatabase(backend, readOnly);
-        } else {
-            return new RustSupportSQLiteDatabase(backend, readOnly);
-        }
-    }
+    protected abstract SupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly);
 }

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustV11SQLiteOpenHelperFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustV11SQLiteOpenHelperFactory.java
@@ -24,10 +24,10 @@ import net.ankiweb.rsdroid.BackendFactory;
 /**
  * Implementation of {@link SupportSQLiteOpenHelper.Factory} using the Anki Desktop backend
  */
-public class RustSQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Factory {
+public class RustV11SQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Factory {
     private final BackendFactory backendFactory;
 
-    public RustSQLiteOpenHelperFactory(BackendFactory backendFactory) {
+    public RustV11SQLiteOpenHelperFactory(BackendFactory backendFactory) {
         this.backendFactory = backendFactory;
     }
 

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustV11SupportSQLiteOpenHelper.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustV11SupportSQLiteOpenHelper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.database;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+
+import net.ankiweb.rsdroid.BackendFactory;
+import net.ankiweb.rsdroid.BackendUtils;
+import net.ankiweb.rsdroid.BackendV1;
+
+import timber.log.Timber;
+
+public class RustV11SupportSQLiteOpenHelper extends RustSupportSQLiteOpenHelper {
+
+    public RustV11SupportSQLiteOpenHelper(@NonNull Configuration configuration, BackendFactory backendFactory) {
+        super(configuration, backendFactory);
+    }
+
+    public RustV11SupportSQLiteOpenHelper(@NonNull BackendV1 backend) {
+        super(backend);
+    }
+
+    @Override
+    protected SupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly) {
+        Timber.d("createRustSupportSQLiteDatabase");
+        if (configuration != null) {
+            BackendV1 backend = backendFactory.getBackend();
+            BackendUtils.openAnkiDroidCollection(backend, configuration.name);
+            return new RustSupportSQLiteDatabase(backend, readOnly);
+        } else {
+            return new RustSupportSQLiteDatabase(backend, readOnly);
+        }
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustVNextSQLiteOpenHelperFactory.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustVNextSQLiteOpenHelperFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.database;
+
+import androidx.annotation.NonNull;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+
+import net.ankiweb.rsdroid.BackendFactory;
+
+/**
+ * Implementation of {@link SupportSQLiteOpenHelper.Factory} using the Anki Desktop backend
+ */
+public class RustVNextSQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Factory {
+    private final BackendFactory backendFactory;
+
+    public RustVNextSQLiteOpenHelperFactory(BackendFactory backendFactory) {
+        this.backendFactory = backendFactory;
+    }
+
+    @NonNull
+    @Override
+    public SupportSQLiteOpenHelper create(@NonNull SupportSQLiteOpenHelper.Configuration configuration) {
+        return new RustVNextSupportSQLiteOpenHelper(configuration, backendFactory);
+    }
+}

--- a/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustVNextSupportSQLiteOpenHelper.java
+++ b/rsdroid/src/main/java/net/ankiweb/rsdroid/database/RustVNextSupportSQLiteOpenHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.ankiweb.rsdroid.database;
+
+import androidx.annotation.NonNull;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+import net.ankiweb.rsdroid.BackendFactory;
+import net.ankiweb.rsdroid.BackendV1;
+
+import timber.log.Timber;
+
+public class RustVNextSupportSQLiteOpenHelper extends RustSupportSQLiteOpenHelper {
+
+    public RustVNextSupportSQLiteOpenHelper(@NonNull Configuration configuration, BackendFactory backendFactory) {
+        super(configuration, backendFactory);
+    }
+
+    public RustVNextSupportSQLiteOpenHelper(@NonNull BackendV1 backend) {
+        super(backend);
+    }
+
+    @Override
+    protected SupportSQLiteDatabase createRustSupportSQLiteDatabase(@SuppressWarnings("SameParameterValue") boolean readOnly) {
+        Timber.d("createRustSupportSQLiteDatabase");
+        if (configuration != null) {
+            BackendV1 backend = backendFactory.getBackend();
+            // openCollection opens and upgrades the collection
+            backend.openCollection(configuration.name, null, null, null);
+            return new RustSupportSQLiteDatabase(backend, readOnly);
+        } else {
+            return new RustSupportSQLiteDatabase(backend, readOnly);
+        }
+    }
+}

--- a/rsdroid/src/test/java/net/ankiweb/CollectionCreationTest.java
+++ b/rsdroid/src/test/java/net/ankiweb/CollectionCreationTest.java
@@ -11,7 +11,7 @@ import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import net.ankiweb.rsdroid.BackendFactory;
-import net.ankiweb.rsdroid.database.RustSupportSQLiteOpenHelper;
+import net.ankiweb.rsdroid.database.RustV11SupportSQLiteOpenHelper;
 import net.ankiweb.rsdroid.testing.RustBackendLoader;
 
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class CollectionCreationTest {
 
         Configuration config = getConfiguration(path);
 
-        SupportSQLiteDatabase database = new RustSupportSQLiteOpenHelper(config, backendV1).getWritableDatabase();
+        SupportSQLiteDatabase database = new RustV11SupportSQLiteOpenHelper(config, backendV1).getWritableDatabase();
 
         database.beginTransaction();
         try {


### PR DESCRIPTION
Allows for schema V16 handling

We don't hardcode the version in the class name, as that means we'll need to change later

Lots of boilerplate due to Android Db requirements, sadly.