### PR TITLE
release: 0.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Adapter allowing AnkiDroid to leverage Anki Desktop's Rust-based business logic 
 ## Installation
 
 ```gradle
-    implementation "io.github.david-allison-1:anki-android-backend:0.1.9"
-    testImplementation "io.github.david-allison-1:anki-android-backend-testing:0.1.9"
+    implementation "io.github.david-allison-1:anki-android-backend:0.1.10"
+    testImplementation "io.github.david-allison-1:anki-android-backend-testing:0.1.10"
 ```
 
 ## Folders

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 GROUP=io.github.david-allison-1
-VERSION_NAME=0.1.9
+VERSION_NAME=0.1.10
 
 POM_INCEPTION_YEAR=2020
 


### PR DESCRIPTION
Add: BackendV16Factory - allows openCollection which upgrades to
  a V16 database
Add: BackendV11Factory - to replace BackendFactory
Modify: BackendV1.openCollection now calls through to the Anki
   openCollection command
   Note: openAnkiDroidCollection is still used in V11 code, which
   uses our custom "open Collection" method