### PR TITLE
use stable rust for publish

### DIFF
--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -18,9 +18,8 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: nightly # nightly is currently required for Robolectric Testing
+        toolchain: stable
         override: true
-        components: rustfmt, clippy
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets


### PR DESCRIPTION
"build" uses it and it works

Added in 7db01e24a720dc68f4d4cebe6f5acb571d750324

copied from robolectric_build.yml

Fixes #129