### PR TITLE
fix: pin toolchain at 1.54.0

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -27,8 +27,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -25,8 +25,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/publish_library.yml
+++ b/.github/workflows/publish_library.yml
@@ -20,8 +20,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/publish_testing.yml
+++ b/.github/workflows/publish_testing.yml
@@ -18,8 +18,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/robolectric_build.yml
+++ b/.github/workflows/robolectric_build.yml
@@ -42,8 +42,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 7 targets.
     - name: Install Rust Targets

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -50,8 +50,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 4 targets.
     - name: Install Rust Targets

--- a/.github/workflows/windows_pure_build.yml
+++ b/.github/workflows/windows_pure_build.yml
@@ -16,8 +16,9 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1.0.6
       with:
-        toolchain: stable
+        toolchain: 1.54.0
         override: true
+        components: rustfmt
 
     # actions-rs only accepts "target" (although a "targets" param to be added in v2). We need 4 targets.
     - name: Install Rust Targets


### PR DESCRIPTION
1.55.0 broke the build:

```
error: unused borrow that must be used
   --> anki/rslib/src/sync/http_client.rs:330:1
    |
330 | #[pin_project]
    | ^^^^^^^^^^^^^^
    |
note: the lint level is defined here
   --> anki/rslib/src/lib.rs:4:9
    |
4   | #![deny(unused_must_use)]
    |         ^^^^^^^^^^^^^^^
    = note: this error originates in the derive macro
    `::pin_project::__private::__PinProjectInternalDerive`
     (in Nightly builds, run with -Z macro-backtrace for more info)

```